### PR TITLE
eventually: implement Aggregate trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,4 @@
+[workspace]
+members = [
+    "eventually"
+]

--- a/eventually/Cargo.toml
+++ b/eventually/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "eventually"
+version = "0.1.0"
+authors = ["Danilo Cianfrone <danilocianfr@gmail.com>"]
+edition = "2018"
+
+[dependencies]

--- a/eventually/examples/optional_person.rs
+++ b/eventually/examples/optional_person.rs
@@ -1,0 +1,102 @@
+#![allow(warnings, dead_code)]
+
+use eventually::aggregate::{
+    optional::{AsAggregate, OptionalAggregate},
+    Aggregate,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+/// Person is the main entity in our small domain.
+struct Person {
+    name: String,
+    last_name: String,
+    version: u64,
+    married_to: Option<String>,
+}
+
+#[derive(Debug)]
+/// Event contains all the possible domain events related to Person.
+enum Event {
+    WasBorn { name: String, last_name: String },
+    ChangedName { name: String, last_name: String },
+    GotMarriedTo(String),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+/// Error contains all the possible errors that can be raised while
+/// applying domain events to a Person state.
+enum Error {
+    PersonNotFound,
+    PersonAlreadyExists,
+}
+
+impl OptionalAggregate for Person {
+    type State = Self;
+    type Event = Event;
+    type Error = Error;
+
+    fn initial(event: Self::Event) -> Result<Self::State, Self::Error> {
+        match event {
+            Event::WasBorn { name, last_name } => Ok(Person {
+                name,
+                last_name,
+                married_to: None,
+                version: 1,
+            }),
+            _ => Err(Error::PersonNotFound),
+        }
+    }
+
+    fn apply_next(mut state: Self::State, event: Self::Event) -> Result<Self::State, Self::Error> {
+        state.version += 1;
+
+        match event {
+            Event::WasBorn { .. } => return Err(Error::PersonAlreadyExists),
+            Event::ChangedName { name, last_name } => {
+                state.name = name;
+                state.last_name = last_name;
+            }
+            Event::GotMarriedTo(person) => {
+                state.married_to = Some(person);
+            }
+        };
+
+        Ok(state)
+    }
+}
+
+fn main() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_folds_multiple_events_correctly() {
+        let result = AsAggregate::<Person>::fold(
+            None,
+            vec![
+                Event::WasBorn {
+                    name: "John".to_string(),
+                    last_name: "Doe".to_string(),
+                },
+                Event::ChangedName {
+                    name: "John".to_string(),
+                    last_name: "Carpenter".to_string(),
+                },
+                Event::GotMarriedTo("Somebody".to_string()),
+            ]
+            .into_iter(),
+        );
+
+        assert_eq!(
+            result,
+            Ok(Some(Person {
+                version: 3,
+                name: "John".to_string(),
+                last_name: "Carpenter".to_string(),
+                married_to: Some("Somebody".to_string()),
+            }))
+        );
+    }
+}

--- a/eventually/examples/optional_point.rs
+++ b/eventually/examples/optional_point.rs
@@ -1,0 +1,77 @@
+#![allow(warnings, dead_code)]
+
+use eventually::aggregate::{
+    optional::{AsAggregate, OptionalAggregate},
+    referential::ReferentialAggregate,
+    Aggregate,
+};
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Point(i32, i32);
+
+#[derive(Debug)]
+pub enum PointEvent {
+    WentUp(i32),
+    WentDown(i32),
+    WentLeft(i32),
+    WentRight(i32),
+}
+
+impl ReferentialAggregate for Point {
+    type Event = PointEvent;
+    type Error = std::convert::Infallible;
+
+    fn apply(self, event: Self::Event) -> Result<Self, Self::Error> {
+        Ok(match event {
+            PointEvent::WentUp(quantity) => Point(self.0, self.1 + quantity),
+            PointEvent::WentDown(quantity) => Point(self.0, self.1 - quantity),
+            PointEvent::WentLeft(quantity) => Point(self.0 - quantity, self.1),
+            PointEvent::WentRight(quantity) => Point(self.0 + quantity, self.1),
+        })
+    }
+}
+
+impl OptionalAggregate for Point {
+    type State = Self;
+    type Event = PointEvent;
+    type Error = std::convert::Infallible;
+
+    fn initial(event: Self::Event) -> Result<Self::State, Self::Error> {
+        Point(0, 0).apply(event)
+    }
+
+    fn apply_next(mut state: Self::State, event: Self::Event) -> Result<Self::State, Self::Error> {
+        state.apply(event)
+    }
+}
+
+fn main() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_applies_an_event_correctly() {
+        assert_eq!(
+            AsAggregate::<Point>::apply(None, PointEvent::WentUp(10)),
+            Ok(Some(Point(0, 10))),
+        );
+    }
+
+    #[test]
+    fn it_folds_data_by_using_aggregate_trait() {
+        assert_eq!(
+            AsAggregate::<Point>::fold(
+                None,
+                vec![
+                    PointEvent::WentUp(10),
+                    PointEvent::WentRight(10),
+                    PointEvent::WentDown(5),
+                ]
+                .into_iter()
+            ),
+            Ok(Some(Point(10, 5)))
+        );
+    }
+}

--- a/eventually/examples/person.rs
+++ b/eventually/examples/person.rs
@@ -1,0 +1,201 @@
+#![allow(warnings, dead_code)]
+
+use eventually::aggregate::Aggregate;
+
+#[derive(Debug, Clone, PartialEq)]
+/// Person is the main entity in our small domain.
+struct Person {
+    name: String,
+    last_name: String,
+    version: u64,
+    married_to: Option<String>,
+}
+
+#[derive(Debug)]
+/// Event contains all the possible domain events related to Person.
+enum Event {
+    WasBorn { name: String, last_name: String },
+    ChangedName { name: String, last_name: String },
+    GotMarriedTo(String),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+/// Error contains all the possible errors that can be raised while
+/// applying domain events to a Person state.
+enum Error {
+    PersonNotFound,
+    PersonAlreadyExists,
+}
+
+impl Aggregate for Person {
+    type State = Option<Self>;
+    type Event = Event;
+    type Error = Error;
+
+    fn apply(state: Self::State, event: Self::Event) -> Result<Self::State, Self::Error> {
+        Ok(Some(match state {
+            Some(state) => state.apply_next(event)?,
+            None => Self::initial(event)?,
+        }))
+    }
+}
+
+impl Person {
+    fn initial(event: Event) -> Result<Self, Error> {
+        match event {
+            Event::WasBorn { name, last_name } => Ok(Person {
+                name,
+                last_name,
+                married_to: None,
+                version: 1,
+            }),
+            _ => Err(Error::PersonNotFound),
+        }
+    }
+
+    fn apply_next(mut self, event: Event) -> Result<Self, Error> {
+        self.version += 1;
+
+        match event {
+            Event::WasBorn { .. } => return Err(Error::PersonAlreadyExists),
+            Event::ChangedName { name, last_name } => {
+                self.name = name;
+                self.last_name = last_name;
+            }
+            Event::GotMarriedTo(person) => {
+                self.married_to = Some(person);
+            }
+        };
+
+        Ok(self)
+    }
+}
+
+fn main() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_fails_when_applying_non_initial_events_to_empty_state() {
+        assert_eq!(
+            Person::apply(
+                None,
+                Event::ChangedName {
+                    name: "John".to_string(),
+                    last_name: "Carpenter".to_string(),
+                }
+            ),
+            Err(Error::PersonNotFound)
+        );
+    }
+
+    #[test]
+    fn it_applies_event_successfully() {
+        let mut result = Person::apply(
+            None,
+            Event::WasBorn {
+                name: "John".to_string(),
+                last_name: "Doe".to_string(),
+            },
+        );
+
+        assert_eq!(
+            result,
+            Ok(Some(Person {
+                version: 1,
+                name: "John".to_string(),
+                last_name: "Doe".to_string(),
+                married_to: None,
+            }))
+        );
+
+        result = result.and_then(|state| {
+            Person::apply(
+                state,
+                Event::ChangedName {
+                    name: "John".to_string(),
+                    last_name: "Carpenter".to_string(),
+                },
+            )
+        });
+
+        assert_eq!(
+            result,
+            Ok(Some(Person {
+                version: 2,
+                name: "John".to_string(),
+                last_name: "Carpenter".to_string(),
+                married_to: None,
+            }))
+        );
+
+        result = result
+            .and_then(|state| Person::apply(state, Event::GotMarriedTo("Somebody".to_string())));
+
+        assert_eq!(
+            result,
+            Ok(Some(Person {
+                version: 3,
+                name: "John".to_string(),
+                last_name: "Carpenter".to_string(),
+                married_to: Some("Somebody".to_string()),
+            }))
+        );
+    }
+
+    #[test]
+    fn it_folds_multiple_events_correctly() {
+        let result = Person::fold(
+            None,
+            vec![
+                Event::WasBorn {
+                    name: "John".to_string(),
+                    last_name: "Doe".to_string(),
+                },
+                Event::ChangedName {
+                    name: "John".to_string(),
+                    last_name: "Carpenter".to_string(),
+                },
+                Event::GotMarriedTo("Somebody".to_string()),
+            ]
+            .into_iter(),
+        );
+
+        assert_eq!(
+            result,
+            Ok(Some(Person {
+                version: 3,
+                name: "John".to_string(),
+                last_name: "Carpenter".to_string(),
+                married_to: Some("Somebody".to_string()),
+            }))
+        );
+    }
+
+    #[test]
+    fn it_fails_when_one_of_the_events_cannot_be_applied() {
+        let result = Person::fold(
+            None,
+            vec![
+                Event::WasBorn {
+                    name: "John".to_string(),
+                    last_name: "Doe".to_string(),
+                },
+                // Born twice, should return an Error::PersonAlreadyExists
+                Event::WasBorn {
+                    name: "John".to_string(),
+                    last_name: "Doe".to_string(),
+                },
+                Event::ChangedName {
+                    name: "John".to_string(),
+                    last_name: "Carpenter".to_string(),
+                },
+            ]
+            .into_iter(),
+        );
+
+        assert_eq!(result, Err(Error::PersonAlreadyExists));
+    }
+}

--- a/eventually/examples/point.rs
+++ b/eventually/examples/point.rs
@@ -1,0 +1,83 @@
+#![allow(warnings, dead_code)]
+
+use eventually::aggregate::{
+    referential::{AsAggregate, ReferentialAggregate},
+    Aggregate,
+};
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Point(i32, i32);
+
+#[derive(Debug)]
+pub enum PointEvent {
+    WentUp(i32),
+    WentDown(i32),
+    WentLeft(i32),
+    WentRight(i32),
+}
+
+impl Default for Point {
+    fn default() -> Self {
+        Point(0, 0)
+    }
+}
+
+impl ReferentialAggregate for Point {
+    type Event = PointEvent;
+    type Error = std::convert::Infallible;
+
+    fn apply(self, event: Self::Event) -> Result<Self, Self::Error> {
+        Ok(match event {
+            PointEvent::WentUp(quantity) => Point(self.0, self.1 + quantity),
+            PointEvent::WentDown(quantity) => Point(self.0, self.1 - quantity),
+            PointEvent::WentLeft(quantity) => Point(self.0 - quantity, self.1),
+            PointEvent::WentRight(quantity) => Point(self.0 + quantity, self.1),
+        })
+    }
+}
+
+fn main() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_folds_lots_of_events_together() {
+        let result = Point::default()
+            .fold(
+                vec![
+                    PointEvent::WentUp(10),
+                    PointEvent::WentRight(10),
+                    PointEvent::WentDown(5),
+                ]
+                .into_iter(),
+            )
+            .unwrap();
+
+        assert_eq!(result, Point(10, 5));
+    }
+
+    #[test]
+    fn it_folds_data_by_using_aggregate_trait() {
+        assert_eq!(
+            AsAggregate::<Point>::fold(
+                Point::default(),
+                vec![
+                    PointEvent::WentUp(10),
+                    PointEvent::WentRight(10),
+                    PointEvent::WentDown(5),
+                ]
+                .into_iter(),
+            ),
+            Point::default().fold(
+                vec![
+                    PointEvent::WentUp(10),
+                    PointEvent::WentRight(10),
+                    PointEvent::WentDown(5),
+                ]
+                .into_iter(),
+            )
+        );
+    }
+}

--- a/eventually/src/aggregate/mod.rs
+++ b/eventually/src/aggregate/mod.rs
@@ -1,3 +1,5 @@
+pub mod optional;
+
 /// An Aggregate is an entity which State is composed of one or more
 /// Value-Objects, Entities or Aggregates.
 ///

--- a/eventually/src/aggregate/mod.rs
+++ b/eventually/src/aggregate/mod.rs
@@ -1,4 +1,5 @@
 pub mod optional;
+pub mod referential;
 
 /// An Aggregate is an entity which State is composed of one or more
 /// Value-Objects, Entities or Aggregates.

--- a/eventually/src/aggregate/mod.rs
+++ b/eventually/src/aggregate/mod.rs
@@ -1,0 +1,46 @@
+/// An Aggregate is an entity which State is composed of one or more
+/// Value-Objects, Entities or Aggregates.
+///
+/// State mutations are expressed through clear Domain Events which, if
+/// applied in the same order as they happened chronologically, will yield
+/// the same Aggregate State.
+pub trait Aggregate {
+    /// State of the Aggregate.
+    ///
+    /// Usually this associate type is either `Self`, `Option<Self>` or
+    /// `Option<T>`, depending on whether the Aggregate state is defined
+    /// in a separate data structure or using the same structure that
+    /// implements this trait.
+    type State;
+
+    /// Domain events that express mutations of the Aggregate State.
+    ///
+    /// An `enum` containing all the possible domain events is the
+    /// usual reccomendation.
+    type Event;
+
+    /// Error type returned in `apply` when mutating the Aggregate State
+    /// to the next version fails.
+    ///
+    /// Usually, this error is a validation error type raised when the
+    /// domain event that is being applied is invalid, based on the current State.
+    ///
+    /// Consider using `std::convert::Infallible` (or `!` type if using nightly)
+    /// if the `apply` method doesn't fail.
+    type Error;
+
+    /// Applies the changes described by the domain event in `Self::Event`
+    /// to the current `state` of the `Aggregate`.
+    fn apply(state: Self::State, event: Self::Event) -> Result<Self::State, Self::Error>;
+
+    /// Applies a stream of events to the current `Aggregate` state, returning
+    /// the updated state or an error, if any such happened.
+    fn fold<I>(mut state: Self::State, events: I) -> Result<Self::State, Self::Error>
+    where
+        I: Iterator<Item = Self::Event>,
+    {
+        events.fold(Ok(state), |previous, event| {
+            previous.and_then(|state| Self::apply(state, event))
+        })
+    }
+}

--- a/eventually/src/aggregate/optional.rs
+++ b/eventually/src/aggregate/optional.rs
@@ -1,0 +1,26 @@
+use crate::aggregate::Aggregate;
+
+pub trait OptionalAggregate {
+    type State;
+    type Event;
+    type Error;
+
+    fn initial(event: Self::Event) -> Result<Self::State, Self::Error>;
+
+    fn apply_next(state: Self::State, event: Self::Event) -> Result<Self::State, Self::Error>;
+}
+
+pub struct AsAggregate<T>(std::marker::PhantomData<T>);
+
+impl<T: OptionalAggregate> Aggregate for AsAggregate<T> {
+    type State = Option<T::State>;
+    type Event = T::Event;
+    type Error = T::Error;
+
+    fn apply(state: Self::State, event: Self::Event) -> Result<Self::State, Self::Error> {
+        Ok(Some(match state {
+            None => T::initial(event)?,
+            Some(state) => T::apply_next(state, event)?,
+        }))
+    }
+}

--- a/eventually/src/aggregate/referential.rs
+++ b/eventually/src/aggregate/referential.rs
@@ -1,0 +1,29 @@
+use crate::aggregate::Aggregate;
+
+pub trait ReferentialAggregate: Sized {
+    type Event;
+    type Error;
+
+    fn apply(self, event: Self::Event) -> Result<Self, Self::Error>;
+
+    fn fold<I>(mut self, events: I) -> Result<Self, Self::Error>
+    where
+        I: Iterator<Item = Self::Event>,
+    {
+        events.fold(Ok(self), |previous, event| {
+            previous.and_then(|state| Self::apply(state, event))
+        })
+    }
+}
+
+pub struct AsAggregate<T>(std::marker::PhantomData<T>);
+
+impl<T: ReferentialAggregate> Aggregate for AsAggregate<T> {
+    type State = T;
+    type Event = T::Event;
+    type Error = T::Error;
+
+    fn apply(state: Self::State, event: Self::Event) -> Result<Self::State, Self::Error> {
+        T::apply(state, event)
+    }
+}

--- a/eventually/src/lib.rs
+++ b/eventually/src/lib.rs
@@ -1,1 +1,3 @@
 #![allow(warnings, dead_code)]
+
+pub mod aggregate;

--- a/eventually/src/lib.rs
+++ b/eventually/src/lib.rs
@@ -1,0 +1,1 @@
+#![allow(warnings, dead_code)]


### PR DESCRIPTION
This PR adds the `Aggregate` trait to `eventually` crate.

`Aggregate` is a domain entity which state can be _created_, _mutated_ and _recreated_ by using **Domain Events**.

In order to fulfill these functionalities, an `Aggregate` implementation needs to provide an `apply` method (to apply the event to the current state).

Other traits and [_newtype-pattern_ adapters](https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#using-the-newtype-pattern-to-implement-external-traits-on-external-types) are defined for ease of development in certain common scenarios, such as:

* `OptionalAggregate`: for `Aggregate` implementations where the aggregate state should be `Option<State>`
* `ReferentialAggregate`: for `Aggregate` implementations where the aggregate state should be `Self`, i.e. the same implementor