### PR TITLE
feat: add event store support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/target
+**/target
 **/*.rs.bk
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
-    "eventually"
+    "eventually",
+    "eventually-memory"
 ]

--- a/eventually-memory/Cargo.toml
+++ b/eventually-memory/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "eventually-memory"
+version = "0.3.0"
+authors = ["Danilo Cianfrone <danilocianfr@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+futures = "0.3"
+eventually = { path = "../eventually" }
+
+[dev-dependencies]
+tokio-test = "0.2"
+criterion = "0.3"
+
+[[bench]]
+name = "bench"
+harness = false

--- a/eventually-memory/benches/bench.rs
+++ b/eventually-memory/benches/bench.rs
@@ -1,3 +1,5 @@
+#![allow(warnings)]
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use futures::stream::StreamExt;
@@ -20,29 +22,6 @@ fn read_event_stream(store: &MemoryStore<&'static str, Event>, source_id: &'stat
     tokio_test::block_on(store.stream(source_id, 0).collect::<Vec<Event>>());
 }
 
-fn insert_new_events_concurrently_4_threads() {
-    let store = std::sync::Arc::new(std::sync::Mutex::new(
-        MemoryStore::<&'static str, Event>::default(),
-    ));
-
-    (0..4)
-        .map(|_id| {
-            std::thread::spawn({
-                let clone = store.clone();
-                move || {
-                    let mut store = clone.lock().unwrap();
-                    tokio_test::block_on(store.append(
-                        "benchtest",
-                        0,
-                        vec![Event::A, Event::B, Event::C],
-                    ))
-                    .unwrap();
-                }
-            })
-        })
-        .for_each(|handle| handle.join().unwrap());
-}
-
 fn insert_elements(store: &mut MemoryStore<&'static str, Event>, name: &'static str, num: usize) {
     tokio_test::block_on(store.append(
         name,
@@ -55,21 +34,59 @@ fn insert_elements(store: &mut MemoryStore<&'static str, Event>, name: &'static 
 fn benchmark(c: &mut Criterion) {
     let mut store = MemoryStore::<&'static str, Event>::default();
 
-    insert_elements(&mut store, "benchtest3", 3);
     insert_elements(&mut store, "benchtest10", 10);
     insert_elements(&mut store, "benchtest100", 100);
-    insert_elements(&mut store, "benchtest1000", 1000);
+    insert_elements(&mut store, "benchtest1_000", 1000);
+    insert_elements(&mut store, "benchtest10_000", 10000);
+    insert_elements(&mut store, "benchtest100_000", 100000);
+    insert_elements(&mut store, "benchtest1_000_000", 1000000);
 
-    c.bench_function("insert new events", |b| {
-        b.iter(|| insert_new_events(black_box(&mut store)))
+    c.bench_function("insert events 10", |b| {
+        b.iter(|| insert_elements(black_box(&mut store), black_box("insert_benchtest10"), 10))
     });
 
-    c.bench_function("insert new events (4 threads)", |b| {
-        b.iter(insert_new_events_concurrently_4_threads)
+    c.bench_function("insert events 100", |b| {
+        b.iter(|| insert_elements(black_box(&mut store), black_box("insert_benchtest100"), 100))
     });
 
-    c.bench_function("read stream events 3", |b| {
-        b.iter(|| read_event_stream(black_box(&store), black_box("benchtest3")))
+    c.bench_function("insert events 1_000", |b| {
+        b.iter(|| {
+            insert_elements(
+                black_box(&mut store),
+                black_box("insert_benchtest1_000"),
+                1000,
+            )
+        })
+    });
+
+    c.bench_function("insert events 10_000", |b| {
+        b.iter(|| {
+            insert_elements(
+                black_box(&mut store),
+                black_box("insert_benchtest10_000"),
+                10000,
+            )
+        })
+    });
+
+    c.bench_function("insert events 100_000", |b| {
+        b.iter(|| {
+            insert_elements(
+                black_box(&mut store),
+                black_box("insert_benchtest100_000"),
+                100000,
+            )
+        })
+    });
+
+    c.bench_function("insert events 1_000_000", |b| {
+        b.iter(|| {
+            insert_elements(
+                black_box(&mut store),
+                black_box("insert_benchtest1_000_000"),
+                1000000,
+            )
+        })
     });
 
     c.bench_function("read stream events 10", |b| {
@@ -80,8 +97,20 @@ fn benchmark(c: &mut Criterion) {
         b.iter(|| read_event_stream(black_box(&store), black_box("benchtest100")))
     });
 
-    c.bench_function("read stream events 1000", |b| {
-        b.iter(|| read_event_stream(black_box(&store), black_box("benchtest1000")))
+    c.bench_function("read stream events 1_000", |b| {
+        b.iter(|| read_event_stream(black_box(&store), black_box("benchtest1_000")))
+    });
+
+    c.bench_function("read stream events 10_000", |b| {
+        b.iter(|| read_event_stream(black_box(&store), black_box("benchtest10_000")))
+    });
+
+    c.bench_function("read stream events 100_000", |b| {
+        b.iter(|| read_event_stream(black_box(&store), black_box("benchtest100_000")))
+    });
+
+    c.bench_function("read stream events 1_000_000", |b| {
+        b.iter(|| read_event_stream(black_box(&store), black_box("benchtest1_000_000")))
     });
 }
 

--- a/eventually-memory/benches/bench.rs
+++ b/eventually-memory/benches/bench.rs
@@ -1,0 +1,89 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use futures::stream::StreamExt;
+
+use eventually::store::{ReadStore, WriteStore};
+use eventually_memory::MemoryStore;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+enum Event {
+    A,
+    B,
+    C,
+}
+
+fn insert_new_events(store: &mut MemoryStore<&'static str, Event>) {
+    tokio_test::block_on(store.append("benchtest", 0, vec![Event::A, Event::B, Event::C])).unwrap()
+}
+
+fn read_event_stream(store: &MemoryStore<&'static str, Event>, source_id: &'static str) {
+    tokio_test::block_on(store.stream(source_id, 0).collect::<Vec<Event>>());
+}
+
+fn insert_new_events_concurrently_4_threads() {
+    let store = std::sync::Arc::new(std::sync::Mutex::new(
+        MemoryStore::<&'static str, Event>::default(),
+    ));
+
+    (0..4)
+        .map(|_id| {
+            std::thread::spawn({
+                let clone = store.clone();
+                move || {
+                    let mut store = clone.lock().unwrap();
+                    tokio_test::block_on(store.append(
+                        "benchtest",
+                        0,
+                        vec![Event::A, Event::B, Event::C],
+                    ))
+                    .unwrap();
+                }
+            })
+        })
+        .for_each(|handle| handle.join().unwrap());
+}
+
+fn insert_elements(store: &mut MemoryStore<&'static str, Event>, name: &'static str, num: usize) {
+    tokio_test::block_on(store.append(
+        name,
+        0,
+        (0..=num).map(|_idx| Event::A).collect::<Vec<Event>>(),
+    ))
+    .unwrap()
+}
+
+fn benchmark(c: &mut Criterion) {
+    let mut store = MemoryStore::<&'static str, Event>::default();
+
+    insert_elements(&mut store, "benchtest3", 3);
+    insert_elements(&mut store, "benchtest10", 10);
+    insert_elements(&mut store, "benchtest100", 100);
+    insert_elements(&mut store, "benchtest1000", 1000);
+
+    c.bench_function("insert new events", |b| {
+        b.iter(|| insert_new_events(black_box(&mut store)))
+    });
+
+    c.bench_function("insert new events (4 threads)", |b| {
+        b.iter(insert_new_events_concurrently_4_threads)
+    });
+
+    c.bench_function("read stream events 3", |b| {
+        b.iter(|| read_event_stream(black_box(&store), black_box("benchtest3")))
+    });
+
+    c.bench_function("read stream events 10", |b| {
+        b.iter(|| read_event_stream(black_box(&store), black_box("benchtest10")))
+    });
+
+    c.bench_function("read stream events 100", |b| {
+        b.iter(|| read_event_stream(black_box(&store), black_box("benchtest100")))
+    });
+
+    c.bench_function("read stream events 1000", |b| {
+        b.iter(|| read_event_stream(black_box(&store), black_box("benchtest1000")))
+    });
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/eventually-memory/src/lib.rs
+++ b/eventually-memory/src/lib.rs
@@ -1,0 +1,140 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+use futures::{
+    future::{ok, Ready},
+    stream::{iter, pending, BoxStream, StreamExt},
+};
+
+use eventually::store::{ReadStore, WriteStore};
+
+pub struct MemoryStore<SourceId, Event> {
+    store: Arc<RwLock<HashMap<SourceId, Vec<Event>>>>,
+}
+
+impl<SourceId, Event> Default for MemoryStore<SourceId, Event>
+where
+    SourceId: std::hash::Hash + Eq,
+{
+    fn default() -> Self {
+        MemoryStore {
+            store: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+}
+
+impl<SourceId, Event> ReadStore for MemoryStore<SourceId, Event>
+where
+    SourceId: std::hash::Hash + Eq,
+    Event: Clone + Send + 'static,
+{
+    type SourceId = SourceId;
+    type Offset = usize;
+    type Event = Event;
+    type Stream = BoxStream<'static, Self::Event>;
+
+    fn stream(&self, source_id: Self::SourceId, from: Self::Offset) -> Self::Stream {
+        let store = self.store.read().unwrap();
+
+        store
+            .get(&source_id)
+            .cloned()
+            .map(move |events| {
+                iter(
+                    events
+                        .into_iter()
+                        .enumerate()
+                        .filter_map(
+                            move |(idx, event)| if idx >= from { Some(event) } else { None },
+                        ),
+                )
+                .boxed()
+            })
+            .unwrap_or_else(|| pending().boxed())
+    }
+}
+
+impl<SourceId, Event> WriteStore for MemoryStore<SourceId, Event>
+where
+    SourceId: std::hash::Hash + Eq,
+    Event: Clone,
+{
+    type SourceId = SourceId;
+    type Offset = usize;
+    type Event = Event;
+    type Error = std::convert::Infallible;
+    type Result = Ready<Result<(), Self::Error>>;
+
+    fn append(
+        &mut self,
+        source_id: Self::SourceId,
+        _from: Self::Offset,
+        events: Vec<Self::Event>,
+    ) -> Self::Result {
+        let mut store = self.store.write().unwrap();
+
+        store
+            .entry(source_id)
+            .and_modify(|vec| {
+                vec.extend(events.clone());
+            })
+            .or_insert(events);
+
+        ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use futures::stream::StreamExt;
+
+    #[derive(Debug, PartialEq, Eq, Clone)]
+    enum Event {
+        A,
+        B,
+        C,
+    }
+
+    #[test]
+    fn it_works() {
+        let mut store = MemoryStore::<&'static str, Event>::default();
+
+        tokio_test::block_on(store.append(
+            "stream1",
+            0 as usize,
+            vec![Event::A, Event::B, Event::C],
+        ))
+        .unwrap();
+
+        assert_eq!(
+            tokio_test::block_on(store.stream("stream1", 0).collect::<Vec<Event>>()),
+            vec![Event::A, Event::B, Event::C]
+        );
+
+        tokio_test::block_on(store.append(
+            "stream1",
+            0 as usize,
+            vec![Event::B, Event::C, Event::A],
+        ))
+        .unwrap();
+
+        assert_eq!(
+            tokio_test::block_on(store.stream("stream1", 0).collect::<Vec<Event>>()),
+            vec![Event::A, Event::B, Event::C, Event::B, Event::C, Event::A]
+        );
+
+        assert_eq!(
+            tokio_test::block_on(store.stream("stream1", 3).collect::<Vec<Event>>()),
+            vec![Event::B, Event::C, Event::A]
+        );
+
+        assert_eq!(
+            tokio_test::block_on(store.stream("stream1", 7).collect::<Vec<Event>>()),
+            vec![]
+        );
+    }
+}

--- a/eventually/Cargo.toml
+++ b/eventually/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventually"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 authors = ["Danilo Cianfrone <danilocianfr@gmail.com>"]
 license = "MIT"
@@ -15,7 +15,7 @@ categories = ["ddd", "event-sourcing", "cqrs", "aggregate"]
 keywords = ["architecture", "ddd", "event-sourcing", "cqrs"]
 
 [dependencies]
-async-trait = "0.1"
+futures = "0.3"
 
 [dev-dependencies]
 tokio-test = "0.2"

--- a/eventually/examples/optional_point.rs
+++ b/eventually/examples/optional_point.rs
@@ -1,6 +1,6 @@
 #![allow(warnings, dead_code)]
 
-use async_trait::async_trait;
+use futures::future::{ok, Ready};
 
 use eventually::{
     aggregate::{
@@ -61,17 +61,14 @@ pub enum PointCommand {
     GoRight(i32),
 }
 
-#[async_trait]
 impl StaticCommandHandler for Point {
     type Command = PointCommand;
     type Aggregate = AsAggregate<Self>;
     type Error = std::convert::Infallible;
+    type Result = Ready<Result<Vec<EventOf<Self::Aggregate>>, Self::Error>>;
 
-    async fn handle(
-        state: &StateOf<Self::Aggregate>,
-        command: Self::Command,
-    ) -> Result<Vec<EventOf<Self::Aggregate>>, Self::Error> {
-        Ok(vec![match command {
+    fn handle(state: &StateOf<Self::Aggregate>, command: Self::Command) -> Self::Result {
+        ok(vec![match command {
             PointCommand::GoUp(y) => PointEvent::WentUp(y),
             PointCommand::GoDown(y) => PointEvent::WentDown(y),
             PointCommand::GoLeft(x) => PointEvent::WentLeft(x),

--- a/eventually/src/command/mod.rs
+++ b/eventually/src/command/mod.rs
@@ -1,18 +1,14 @@
 pub mod r#static;
 
-use async_trait::async_trait;
+use std::future::Future;
 
 use crate::aggregate::{Aggregate, EventOf, StateOf};
 
-#[async_trait]
 pub trait Handler {
     type Command;
     type Aggregate: Aggregate;
     type Error;
+    type Result: Future<Output = Result<Vec<EventOf<Self::Aggregate>>, Self::Error>>;
 
-    async fn handle(
-        &self,
-        state: &StateOf<Self::Aggregate>,
-        command: Self::Command,
-    ) -> Result<Vec<EventOf<Self::Aggregate>>, Self::Error>;
+    fn handle(&self, state: &StateOf<Self::Aggregate>, command: Self::Command) -> Self::Result;
 }

--- a/eventually/src/lib.rs
+++ b/eventually/src/lib.rs
@@ -2,3 +2,4 @@
 
 pub mod aggregate;
 pub mod command;
+pub mod store;

--- a/eventually/src/lib.rs
+++ b/eventually/src/lib.rs
@@ -1,5 +1,11 @@
-#![allow(warnings, dead_code)]
+#![allow(warnings)]
 
 pub mod aggregate;
 pub mod command;
 pub mod store;
+
+pub use {
+    aggregate::Aggregate,
+    command::Handler as CommandHandler,
+    store::{ReadStore, WriteStore},
+};

--- a/eventually/src/store.rs
+++ b/eventually/src/store.rs
@@ -1,0 +1,27 @@
+use std::future::Future;
+
+use futures::Stream;
+
+pub trait ReadStore {
+    type SourceId: Eq;
+    type Offset: PartialOrd;
+    type Event;
+    type Stream: Stream<Item = Self::Event>;
+
+    fn stream(&self, source_id: Self::SourceId, from: Self::Offset) -> Self::Stream;
+}
+
+pub trait WriteStore {
+    type SourceId: Eq;
+    type Offset: PartialOrd;
+    type Event;
+    type Error;
+    type Result: Future<Output = Result<(), Self::Error>>;
+
+    fn append(
+        &mut self,
+        source_id: Self::SourceId,
+        from: Self::Offset,
+        events: Vec<Self::Event>,
+    ) -> Self::Result;
+}

--- a/eventually/src/store.rs
+++ b/eventually/src/store.rs
@@ -11,10 +11,7 @@ pub trait ReadStore {
     fn stream(&self, source_id: Self::SourceId, from: Self::Offset) -> Self::Stream;
 }
 
-pub trait WriteStore {
-    type SourceId: Eq;
-    type Offset: PartialOrd;
-    type Event;
+pub trait WriteStore: ReadStore {
     type Error;
     type Result: Future<Output = Result<(), Self::Error>>;
 


### PR DESCRIPTION
The proposed Event Store design is to have two separate traits:

- `ReadStore` for streaming persisted events
- `WriteStore` for committing new events

