### PR TITLE
eventually: add AggregateExt supertrait

### DIFF
--- a/eventually/examples/optional_person.rs
+++ b/eventually/examples/optional_person.rs
@@ -2,7 +2,7 @@
 
 use eventually::aggregate::{
     optional::{AsAggregate, OptionalAggregate},
-    Aggregate,
+    Aggregate, AggregateExt,
 };
 
 #[derive(Debug, Clone, PartialEq)]

--- a/eventually/examples/optional_point.rs
+++ b/eventually/examples/optional_point.rs
@@ -1,4 +1,4 @@
-#![allow(warnings, dead_code)]
+#![allow(warnings)]
 
 use futures::future::{ok, Ready};
 
@@ -6,7 +6,7 @@ use eventually::{
     aggregate::{
         optional::{AsAggregate, OptionalAggregate},
         referential::ReferentialAggregate,
-        Aggregate, EventOf, StateOf,
+        Aggregate, AggregateExt, EventOf, StateOf,
     },
     command::{
         r#static::{AsHandler, StaticHandler as StaticCommandHandler},

--- a/eventually/examples/person.rs
+++ b/eventually/examples/person.rs
@@ -1,6 +1,6 @@
 #![allow(warnings, dead_code)]
 
-use eventually::aggregate::Aggregate;
+use eventually::aggregate::{Aggregate, AggregateExt};
 
 #[derive(Debug, Clone, PartialEq)]
 /// Person is the main entity in our small domain.

--- a/eventually/examples/point.rs
+++ b/eventually/examples/point.rs
@@ -2,7 +2,7 @@
 
 use eventually::aggregate::{
     referential::{AsAggregate, ReferentialAggregate},
-    Aggregate,
+    Aggregate, AggregateExt,
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -43,22 +43,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn it_folds_lots_of_events_together() {
-        let result = Point::default()
-            .fold(
-                vec![
-                    PointEvent::WentUp(10),
-                    PointEvent::WentRight(10),
-                    PointEvent::WentDown(5),
-                ]
-                .into_iter(),
-            )
-            .unwrap();
-
-        assert_eq!(result, Point(10, 5));
-    }
-
-    #[test]
     fn it_folds_data_by_using_aggregate_trait() {
         assert_eq!(
             AsAggregate::<Point>::fold(
@@ -70,14 +54,7 @@ mod tests {
                 ]
                 .into_iter(),
             ),
-            Point::default().fold(
-                vec![
-                    PointEvent::WentUp(10),
-                    PointEvent::WentRight(10),
-                    PointEvent::WentDown(5),
-                ]
-                .into_iter(),
-            )
+            Ok(Point(10, 5))
         );
     }
 }

--- a/eventually/src/aggregate/mod.rs
+++ b/eventually/src/aggregate/mod.rs
@@ -1,12 +1,18 @@
 pub mod optional;
 pub mod referential;
+pub mod util;
 pub mod versioned;
+
+pub use util::AggregateExt;
 
 /// State type of the Aggregate specified.
 pub type StateOf<A: Aggregate> = A::State;
 
 /// Event type of the Aggregate specified.
 pub type EventOf<A: Aggregate> = A::Event;
+
+/// Error type of the Aggregate specified.
+pub type ErrorOf<A: Aggregate> = A::Error;
 
 /// An Aggregate is an entity which State is composed of one or more
 /// Value-Objects, Entities or Aggregates.
@@ -42,15 +48,4 @@ pub trait Aggregate {
     /// Applies the changes described by the domain event in `Self::Event`
     /// to the current `state` of the `Aggregate`.
     fn apply(state: Self::State, event: Self::Event) -> Result<Self::State, Self::Error>;
-
-    /// Applies a stream of events to the current `Aggregate` state, returning
-    /// the updated state or an error, if any such happened.
-    fn fold<I>(mut state: Self::State, events: I) -> Result<Self::State, Self::Error>
-    where
-        I: Iterator<Item = Self::Event>,
-    {
-        events.fold(Ok(state), |previous, event| {
-            previous.and_then(|state| Self::apply(state, event))
-        })
-    }
 }

--- a/eventually/src/aggregate/referential.rs
+++ b/eventually/src/aggregate/referential.rs
@@ -5,15 +5,6 @@ pub trait ReferentialAggregate: Sized {
     type Error;
 
     fn apply(self, event: Self::Event) -> Result<Self, Self::Error>;
-
-    fn fold<I>(mut self, events: I) -> Result<Self, Self::Error>
-    where
-        I: Iterator<Item = Self::Event>,
-    {
-        events.fold(Ok(self), |previous, event| {
-            previous.and_then(|state| Self::apply(state, event))
-        })
-    }
 }
 
 pub struct AsAggregate<T>(std::marker::PhantomData<T>);

--- a/eventually/src/aggregate/util.rs
+++ b/eventually/src/aggregate/util.rs
@@ -1,0 +1,39 @@
+use std::{future::Future, pin::Pin};
+
+use futures::{Stream, StreamExt};
+
+use crate::aggregate::{
+    optional::{AsAggregate as OptionalAsAggregate, OptionalAggregate},
+    referential::{AsAggregate as ReferentialAsAggregate, ReferentialAggregate},
+    versioned::AsAggregate as VersionedAggregate,
+    Aggregate,
+};
+
+pub trait AggregateExt: Aggregate {
+    /// Applies a stream of events to the current `Aggregate` state, returning
+    /// the updated state or an error, if any such happened.
+    fn fold(
+        mut state: Self::State,
+        events: impl Iterator<Item = Self::Event>,
+    ) -> Result<Self::State, Self::Error> {
+        events.fold(Ok(state), |previous, event| {
+            previous.and_then(|state| Self::apply(state, event))
+        })
+    }
+
+    fn async_fold<'a>(
+        mut state: Self::State,
+        events: impl Stream<Item = Self::Event> + Send + 'a,
+    ) -> Pin<Box<dyn Future<Output = Result<Self::State, Self::Error>> + Send + 'a>>
+    where
+        Self::State: Send + 'a,
+        Self::Event: Send + 'a,
+        Self::Error: Send + 'a,
+    {
+        Box::pin(events.fold(Ok(state), |previous, event| {
+            async move { previous.and_then(|state| Self::apply(state, event)) }
+        }))
+    }
+}
+
+impl<T: Aggregate> AggregateExt for T {}

--- a/eventually/src/aggregate/versioned.rs
+++ b/eventually/src/aggregate/versioned.rs
@@ -6,8 +6,7 @@ pub trait Versioned {
     fn version(&self) -> u64;
 }
 
-#[derive(Clone, PartialEq)]
-#[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct State<T> {
     pub data: T,
     pub version: u64,


### PR DESCRIPTION
Add an `AggregateExt` supertrait extension with:

* `fn async_fold()` to fold an Aggregate given a `futures::Stream`
* `fn fold()`, previous implementation in `Aggregate` but now moved here 