### PR TITLE
eventually-memory: fix stuck future on MemoryStore::stream

### DIFF
--- a/eventually-memory/src/lib.rs
+++ b/eventually-memory/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
 
 use futures::{
     future::{ok, Ready},
-    stream::{iter, pending, BoxStream, StreamExt},
+    stream::{empty, iter, BoxStream, StreamExt},
 };
 
 use eventually::store::{ReadStore, WriteStore};
@@ -55,7 +55,7 @@ where
                 )
                 .boxed()
             })
-            .unwrap_or_else(|| pending().boxed())
+            .unwrap_or_else(|| empty().boxed())
     }
 }
 


### PR DESCRIPTION
The current implementation of `MemoryStore::stream` returns `futures::future::pending` in case the backing stream is empty.

This makes the `stream.collect::<Vec>().await` call hang on `await`, since the future will never complete.

Replace the `futures::future::pending` to `futures::future::empty`.