### PR TITLE
feat: add command::dispatcher::Dispatcher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [workspace]
 members = [
     "eventually",
-    "eventually-memory"
+    "eventually-memory",
+
+    # Examples crate
+    "eventually-examples"
 ]

--- a/eventually-examples/Cargo.toml
+++ b/eventually-examples/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "eventually-examples"
+version = "0.1.0"
+authors = ["Danilo Cianfrone <danilocianfr@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+futures = "0.3"
+eventually = { path = "../eventually" }
+eventually-memory = { path = "../eventually-memory" }
+tokio-test = "0.2"
+rand = "0.7"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[lib]
+name = "point"
+path = "src/point.rs"
+
+[[bin]]
+name = "main"
+path = "src/main.rs"
+
+[[bench]]
+name = "bench"
+harness = false

--- a/eventually-examples/benches/bench.rs
+++ b/eventually-examples/benches/bench.rs
@@ -1,0 +1,63 @@
+#![allow(warnings)]
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use futures::stream::StreamExt;
+
+use rand::prelude::*;
+
+use eventually::{
+    aggregate::{optional::AsAggregate, versioned::AsAggregate as VersionedAggregate},
+    command::{
+        dispatcher::Dispatcher,
+        r#static::{AsHandler, StaticHandler},
+    },
+};
+use eventually_memory::MemoryStore;
+
+type DispatcherType =
+    Dispatcher<MemoryStore<std::string::String, point::Event>, AsHandler<point::CommandHandler>>;
+
+fn dispatch(dispatcher: &mut DispatcherType, id: &'static str) {
+    let mut rng = rand::thread_rng();
+    let random: i32 = rng.gen::<i32>() % 100;
+    let choice: u8 = rng.gen::<u8>() % 4;
+
+    tokio_test::block_on(dispatcher.dispatch(match choice {
+        0 => point::Command::GoUp {
+            id: id.to_string(),
+            v: random,
+        },
+        1 => point::Command::GoDown {
+            id: id.to_string(),
+            v: random,
+        },
+        2 => point::Command::GoLeft {
+            id: id.to_string(),
+            v: random,
+        },
+        3 => point::Command::GoRight {
+            id: id.to_string(),
+            v: random,
+        },
+        _ => panic!("should not be entered"),
+    }));
+}
+
+fn benchmark(c: &mut Criterion) {
+    let store = eventually_memory::MemoryStore::<String, point::Event>::default();
+    let handler = point::CommandHandler::as_handler();
+
+    let mut dispatcher = Dispatcher::new(store, handler);
+
+    tokio_test::block_on(dispatcher.dispatch(point::Command::Register {
+        id: "benchmark".to_string(),
+    }));
+
+    c.bench_function("dispatch", |b| {
+        b.iter(|| dispatch(black_box(&mut dispatcher), black_box("benchmark")))
+    });
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/eventually-examples/src/main.rs
+++ b/eventually-examples/src/main.rs
@@ -1,0 +1,74 @@
+use eventually::command::{
+    dispatcher::{Dispatcher, Error},
+    r#static::StaticHandler,
+};
+
+use rand::prelude::*;
+
+type DispatchError = Error<point::EventError, point::CommandError, std::convert::Infallible>;
+
+fn main() {
+    let store = eventually_memory::MemoryStore::<String, point::Event>::default();
+    let handler = point::CommandHandler::as_handler();
+
+    let mut dispatcher = Dispatcher::new(store, handler);
+
+    let result: Result<(), DispatchError> = tokio_test::block_on(async {
+        println!(
+            "Register: {:?}",
+            dispatcher
+                .dispatch(point::Command::Register {
+                    id: "MyPoint".to_string(),
+                })
+                .await?
+        );
+
+        for _i in 0..1000 - 1 {
+            let mut rng = rand::thread_rng();
+            let random: i32 = rng.gen::<i32>() % 100;
+            let choice: u8 = rng.gen::<u8>() % 4;
+
+            println!(
+                "State: {:?}",
+                dispatcher
+                    .dispatch(match choice {
+                        0 => point::Command::GoUp {
+                            id: "MyPoint".to_string(),
+                            v: random
+                        },
+                        1 => point::Command::GoDown {
+                            id: "MyPoint".to_string(),
+                            v: random
+                        },
+                        2 => point::Command::GoLeft {
+                            id: "MyPoint".to_string(),
+                            v: random
+                        },
+                        3 => point::Command::GoRight {
+                            id: "MyPoint".to_string(),
+                            v: random
+                        },
+                        _ => panic!("should not be entered"),
+                    })
+                    .await?
+            );
+        }
+
+        dispatcher
+            .dispatch(point::Command::Register {
+                id: "MyPoint".to_string(),
+            })
+            .await?;
+
+        Ok(())
+    });
+
+    assert_eq!(
+        result,
+        Err(Error::CommandFailed(
+            point::CommandError::AlreadyRegistered("MyPoint".to_string())
+        ))
+    );
+
+    println!("Result: {}", result.unwrap_err());
+}

--- a/eventually-examples/src/point.rs
+++ b/eventually-examples/src/point.rs
@@ -1,0 +1,152 @@
+use futures::future::{err, ok, Ready};
+
+use eventually::{
+    aggregate::{
+        optional::{AsAggregate, OptionalAggregate},
+        referential::ReferentialAggregate,
+        versioned::AsAggregate as VersionedAggregate,
+        EventOf, StateOf,
+    },
+    command::{dispatcher::Identifiable, r#static::StaticHandler as StaticCommandHandler},
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Command {
+    Register { id: String },
+    GoUp { id: String, v: i32 },
+    GoDown { id: String, v: i32 },
+    GoLeft { id: String, v: i32 },
+    GoRight { id: String, v: i32 },
+}
+
+impl Identifiable for Command {
+    type SourceId = String;
+
+    #[inline]
+    fn source_id(&self) -> Self::SourceId {
+        match self {
+            Command::Register { id } => id.clone(),
+            Command::GoUp { id, .. } => id.clone(),
+            Command::GoDown { id, .. } => id.clone(),
+            Command::GoLeft { id, .. } => id.clone(),
+            Command::GoRight { id, .. } => id.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Event {
+    Registered { id: String },
+    WentUp { v: i32 },
+    WentDown { v: i32 },
+    WentLeft { v: i32 },
+    WentRight { v: i32 },
+}
+
+#[derive(Debug, PartialEq)]
+pub enum CommandError {
+    Unregistered(String),
+    AlreadyRegistered(String),
+}
+
+impl std::error::Error for CommandError {}
+impl std::fmt::Display for CommandError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            CommandError::Unregistered(id) => {
+                write!(f, "Point '{}' has not been registered yet", id)
+            }
+            CommandError::AlreadyRegistered(id) => {
+                write!(f, "Point '{}' has been registered already", id)
+            }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum EventError {
+    Unregistered,
+    AlreadyRegistered,
+}
+
+impl std::error::Error for EventError {}
+impl std::fmt::Display for EventError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            EventError::Unregistered => write!(f, "Point has not been registered yet"),
+            EventError::AlreadyRegistered => write!(f, "Point has been registered already"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct State {
+    id: String,
+    x: i32,
+    y: i32,
+}
+
+impl ReferentialAggregate for State {
+    type Event = Event;
+    type Error = EventError;
+
+    #[inline]
+    fn apply(mut self, event: Self::Event) -> Result<Self, Self::Error> {
+        match event {
+            Event::Registered { .. } => return Err(EventError::AlreadyRegistered),
+            Event::WentUp { v } => self.y += v,
+            Event::WentDown { v } => self.y -= v,
+            Event::WentLeft { v } => self.x -= v,
+            Event::WentRight { v } => self.x -= v,
+        };
+
+        Ok(self)
+    }
+}
+
+pub struct Root;
+impl OptionalAggregate for Root {
+    type State = State;
+    type Event = Event;
+    type Error = EventError;
+
+    #[inline]
+    fn initial(event: Self::Event) -> Result<Self::State, Self::Error> {
+        match event {
+            Event::Registered { id } => Ok(State { id, x: 0, y: 0 }),
+            _ => Err(EventError::Unregistered),
+        }
+    }
+
+    #[inline]
+    fn apply_next(state: Self::State, event: Self::Event) -> Result<Self::State, Self::Error> {
+        state.apply(event)
+    }
+}
+
+pub struct CommandHandler;
+impl StaticCommandHandler for CommandHandler {
+    type Command = Command;
+    type Aggregate = VersionedAggregate<AsAggregate<Root>>;
+    type Error = CommandError;
+    type Result = Ready<Result<Vec<EventOf<Self::Aggregate>>, Self::Error>>;
+
+    fn handle(state: &StateOf<Self::Aggregate>, command: Self::Command) -> Self::Result {
+        match &state.data {
+            None => match command {
+                Command::Register { id } => ok(vec![Event::Registered { id }]),
+                Command::GoUp { id, .. } => err(CommandError::Unregistered(id)),
+                Command::GoDown { id, .. } => err(CommandError::Unregistered(id)),
+                Command::GoLeft { id, .. } => err(CommandError::Unregistered(id)),
+                Command::GoRight { id, .. } => err(CommandError::Unregistered(id)),
+            },
+            Some(_state) => match command {
+                Command::Register { id } => err(CommandError::AlreadyRegistered(id)),
+                Command::GoUp { v, .. } => ok(vec![Event::WentUp { v }]),
+                Command::GoDown { v, .. } => ok(vec![Event::WentDown { v }]),
+                Command::GoLeft { v, .. } => ok(vec![Event::WentLeft { v }]),
+                Command::GoRight { v, .. } => ok(vec![Event::WentRight { v }]),
+            },
+        }
+    }
+}

--- a/eventually/src/command/dispatcher.rs
+++ b/eventually/src/command/dispatcher.rs
@@ -1,0 +1,119 @@
+use std::{future::Future, pin::Pin};
+
+use futures::StreamExt;
+
+use crate::{
+    aggregate,
+    aggregate::{Aggregate, AggregateExt},
+    command,
+    command::Handler as CommandHandler,
+    store::{ReadStore, WriteStore},
+};
+
+pub type SourceIdOf<I: Identifiable> = I::SourceId;
+
+pub trait Identifiable {
+    type SourceId: Eq;
+
+    fn source_id(&self) -> Self::SourceId;
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Error<A, C, RS> {
+    RecreateStateFailed(A),
+    CommandFailed(C),
+    ApplyStateFailed(A),
+    AppendEventsFailed(RS),
+}
+
+impl<A, C, RS> std::error::Error for Error<A, C, RS>
+where
+    A: std::error::Error,
+    C: std::error::Error,
+    RS: std::error::Error,
+{
+}
+
+impl<A, C, RS> std::fmt::Display for Error<A, C, RS>
+where
+    A: std::error::Error,
+    C: std::error::Error,
+    RS: std::error::Error,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::RecreateStateFailed(e) => write!(f, "Failed to recreate state: {}", e),
+            Error::CommandFailed(e) => write!(f, "Failed to handle command: {}", e),
+            Error::ApplyStateFailed(e) => write!(f, "Failed to apply new events: {}", e),
+            Error::AppendEventsFailed(e) => write!(f, "Failed to append events to store: {}", e),
+        }
+    }
+}
+
+pub struct Dispatcher<Store, Handler> {
+    store: Store,
+    handler: Handler,
+}
+
+impl<Store, Handler> Dispatcher<Store, Handler>
+where
+    Handler: CommandHandler + Send,
+    Store: WriteStore + Send,
+    <Store as ReadStore>::SourceId: Clone + Eq + Send,
+    <Store as ReadStore>::Offset: Default + Send,
+    <Store as ReadStore>::Stream: Send,
+    <Store as WriteStore>::Error: std::error::Error + Send + 'static,
+    command::AggregateOf<Handler>: AggregateExt<Event = <Store as ReadStore>::Event> + Send,
+    command::CommandOf<Handler>: Identifiable<SourceId = <Store as ReadStore>::SourceId> + Send,
+    aggregate::EventOf<command::AggregateOf<Handler>>: Clone + Send,
+    aggregate::StateOf<command::AggregateOf<Handler>>: Default + Send,
+    aggregate::ErrorOf<command::AggregateOf<Handler>>: std::error::Error + Send + 'static,
+    command::ErrorOf<Handler>: std::error::Error + Send + 'static,
+{
+    #[inline]
+    pub fn new(store: Store, handler: Handler) -> Self {
+        Dispatcher { store, handler }
+    }
+
+    pub fn dispatch(
+        &mut self,
+        c: command::CommandOf<Handler>,
+    ) -> impl Future<
+        Output = Result<
+            aggregate::StateOf<command::AggregateOf<Handler>>,
+            Error<aggregate::ErrorOf<command::AggregateOf<Handler>>, Handler::Error, Store::Error>,
+        >,
+    > + '_ {
+        async move {
+            let id = c.source_id();
+
+            let events = self
+                .store
+                .stream(id.clone(), <Store as ReadStore>::Offset::default());
+
+            let state = command::AggregateOf::<Handler>::async_fold(
+                aggregate::StateOf::<command::AggregateOf<Handler>>::default(),
+                events,
+            )
+            .await
+            .map_err(Error::RecreateStateFailed)?;
+
+            let new_events = self
+                .handler
+                .handle(&state, c)
+                .await
+                .map_err(Error::CommandFailed)?;
+
+            let new_state =
+                command::AggregateOf::<Handler>::fold(state, new_events.clone().into_iter())
+                    .map_err(Error::ApplyStateFailed)?;
+
+            self.store
+                .append(id, <Store as ReadStore>::Offset::default(), new_events)
+                .await
+                .map_err(Error::AppendEventsFailed)?;
+
+            Ok(new_state)
+        }
+    }
+}

--- a/eventually/src/command/mod.rs
+++ b/eventually/src/command/mod.rs
@@ -1,8 +1,13 @@
+pub mod dispatcher;
 pub mod r#static;
 
 use std::future::Future;
 
 use crate::aggregate::{Aggregate, EventOf, StateOf};
+
+pub type CommandOf<H: Handler> = H::Command;
+pub type AggregateOf<H: Handler> = H::Aggregate;
+pub type ErrorOf<H: Handler> = H::Error;
 
 pub trait Handler {
     type Command;

--- a/eventually/src/lib.rs
+++ b/eventually/src/lib.rs
@@ -5,7 +5,7 @@ pub mod command;
 pub mod store;
 
 pub use {
-    aggregate::Aggregate,
+    aggregate::{util::AggregateExt, Aggregate},
     command::Handler as CommandHandler,
     store::{ReadStore, WriteStore},
 };


### PR DESCRIPTION
Now that we have `command::Handler` and `store::WriteStore`, we need a third piece of abstraction to:

* read the old events from the store
* recreate the `Aggregate` state
* call the `command::Handler` with the recreated state
* commit the new events to the store

This piece is called `Dispatcher` and lives in the `command::dispatcher` module.

This PR also includes an example-crate, `eventually-examples`, to showcase some possible applications of this crate.