### PR TITLE
eventually: remove `type Result` from command::Handler

### DIFF
--- a/eventually-examples/Cargo.toml
+++ b/eventually-examples/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1"
 futures = "0.3"
 eventually = { path = "../eventually" }
 eventually-memory = { path = "../eventually-memory" }

--- a/eventually-examples/src/main.rs
+++ b/eventually-examples/src/main.rs
@@ -1,15 +1,13 @@
-use eventually::{
-    command::dispatcher::{Dispatcher, Error},
-    optional::CommandHandler,
-    versioned::CommandHandlerExt,
-};
+use eventually::command::dispatcher::{Dispatcher, Error};
+use eventually::optional::CommandHandler;
+use eventually::versioned::{CommandHandlerExt, Versioned};
 
 use rand::prelude::*;
 
 type DispatchError = Error<point::EventError, point::CommandError, std::convert::Infallible>;
 
 fn main() {
-    let store = eventually_memory::MemoryStore::<String, point::Event>::default();
+    let store = eventually_memory::MemoryStore::<String, Versioned<point::Event>>::default();
     let handler = point::Handler.as_handler().versioned();
 
     let mut dispatcher = Dispatcher::new(store, handler);

--- a/eventually/Cargo.toml
+++ b/eventually/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["ddd", "event-sourcing", "cqrs", "aggregate"]
 keywords = ["architecture", "ddd", "event-sourcing", "cqrs"]
 
 [dependencies]
+async-trait = "0.1"
 futures = "0.3"
 
 [dev-dependencies]

--- a/eventually/examples/optional_point.rs
+++ b/eventually/examples/optional_point.rs
@@ -1,10 +1,9 @@
-use futures::future::{ok, Ready};
+use async_trait::async_trait;
 
-use eventually::{
-    aggregate::{EventOf, ReferentialAggregate, StateOf},
-    command::r#static::StaticHandler as StaticCommandHandler,
-    optional::{Aggregate, AsAggregate},
-};
+use eventually::aggregate::{EventOf, ReferentialAggregate, StateOf};
+use eventually::command;
+use eventually::command::r#static::StaticHandler as StaticCommandHandler;
+use eventually::optional::{Aggregate, AsAggregate};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Point(i32, i32);
@@ -63,14 +62,17 @@ pub enum PointCommand {
     GoRight(i32),
 }
 
+#[async_trait]
 impl StaticCommandHandler for Point {
     type Command = PointCommand;
     type Aggregate = AsAggregate<Self>;
     type Error = std::convert::Infallible;
-    type Result = Ready<Result<Vec<EventOf<Self::Aggregate>>, Self::Error>>;
 
-    fn handle(_state: &StateOf<Self::Aggregate>, command: Self::Command) -> Self::Result {
-        ok(vec![match command {
+    async fn handle(
+        _state: &StateOf<Self::Aggregate>,
+        command: Self::Command,
+    ) -> command::Result<EventOf<Self::Aggregate>, Self::Error> {
+        Ok(vec![match command {
             PointCommand::GoUp(y) => PointEvent::WentUp(y),
             PointCommand::GoDown(y) => PointEvent::WentDown(y),
             PointCommand::GoLeft(x) => PointEvent::WentLeft(x),

--- a/eventually/examples/optional_point.rs
+++ b/eventually/examples/optional_point.rs
@@ -135,9 +135,9 @@ mod tests {
         let state = VersionedAggregate::<AsAggregate<Point>>::fold(
             Versioned::default(),
             vec![
-                PointEvent::WentUp(10),
-                PointEvent::WentRight(10),
-                PointEvent::WentDown(5),
+                Versioned::with_version(PointEvent::WentUp(10), 1),
+                Versioned::with_version(PointEvent::WentRight(10), 2),
+                Versioned::with_version(PointEvent::WentDown(5), 3),
             ]
             .into_iter(),
         )

--- a/eventually/src/aggregate/mod.rs
+++ b/eventually/src/aggregate/mod.rs
@@ -17,9 +17,7 @@ pub mod referential;
 
 pub use referential::ReferentialAggregate;
 
-use std::{future::Future, pin::Pin};
-
-use futures::{Stream, StreamExt};
+use futures::{future::BoxFuture, Stream, StreamExt};
 
 /// Alias for the [`State`] type of an [`Aggregate`].
 ///
@@ -119,7 +117,7 @@ pub trait AggregateExt: Aggregate {
     fn async_fold<'a>(
         state: Self::State,
         events: impl Stream<Item = Self::Event> + Send + 'a,
-    ) -> Pin<Box<dyn Future<Output = Result<Self::State, Self::Error>> + Send + 'a>>
+    ) -> BoxFuture<'a, Result<Self::State, Self::Error>>
     where
         Self::State: Send + 'a,
         Self::Event: Send + 'a,

--- a/eventually/src/aggregate/mod.rs
+++ b/eventually/src/aggregate/mod.rs
@@ -17,7 +17,9 @@ pub mod referential;
 
 pub use referential::ReferentialAggregate;
 
-use futures::{future::BoxFuture, Stream, StreamExt};
+use async_trait::async_trait;
+
+use futures::{Stream, StreamExt};
 
 /// Alias for the [`State`] type of an [`Aggregate`].
 ///
@@ -91,6 +93,7 @@ pub trait Aggregate {
 /// Extension trait for [`Aggregate`] containing combinator functions.
 ///
 /// [`Aggregate`]: trait.Aggregate.html
+#[async_trait]
 pub trait AggregateExt: Aggregate {
     /// Applies a _synchronous_ stream of [`Event`]s to the current [`State`],
     /// returning the updated state or an error, if any such happened.
@@ -98,10 +101,10 @@ pub trait AggregateExt: Aggregate {
     /// [`Event`]: trait.Aggregate.html#associatedtype.Event
     /// [`State`]: trait.Aggregate.html#associatedtype.State
     #[inline]
-    fn fold(
-        state: Self::State,
-        events: impl Iterator<Item = Self::Event>,
-    ) -> Result<Self::State, Self::Error> {
+    fn fold<I>(state: Self::State, events: I) -> Result<Self::State, Self::Error>
+    where
+        I: Iterator<Item = Self::Event>,
+    {
         events.fold(Ok(state), |previous, event| {
             previous.and_then(|state| Self::apply(state, event))
         })
@@ -114,18 +117,18 @@ pub trait AggregateExt: Aggregate {
     /// [`Event`]: trait.Aggregate.html#associatedtype.Event
     /// [`State`]: trait.Aggregate.html#associatedtype.State
     #[inline]
-    fn async_fold<'a>(
-        state: Self::State,
-        events: impl Stream<Item = Self::Event> + Send + 'a,
-    ) -> BoxFuture<'a, Result<Self::State, Self::Error>>
+    async fn async_fold<S>(state: Self::State, events: S) -> Result<Self::State, Self::Error>
     where
-        Self::State: Send + 'a,
-        Self::Event: Send + 'a,
-        Self::Error: Send + 'a,
+        S: Stream<Item = Self::Event> + Send,
+        Self::State: Send,
+        Self::Event: Send,
+        Self::Error: Send,
     {
-        Box::pin(events.fold(Ok(state), |previous, event| {
-            async move { previous.and_then(|state| Self::apply(state, event)) }
-        }))
+        events
+            .fold(Ok(state), |previous, event| {
+                async move { previous.and_then(|state| Self::apply(state, event)) }
+            })
+            .await
     }
 }
 

--- a/eventually/src/command/mod.rs
+++ b/eventually/src/command/mod.rs
@@ -1,7 +1,9 @@
 pub mod dispatcher;
 pub mod r#static;
 
-use std::future::Future;
+use std::result::Result as StdResult;
+
+use async_trait::async_trait;
 
 use crate::aggregate::{Aggregate, EventOf, StateOf};
 
@@ -9,11 +11,17 @@ pub type CommandOf<H: Handler> = H::Command;
 pub type AggregateOf<H: Handler> = H::Aggregate;
 pub type ErrorOf<H: Handler> = H::Error;
 
+pub type Result<Event, Error> = StdResult<Vec<Event>, Error>;
+
+#[async_trait]
 pub trait Handler {
     type Command;
     type Aggregate: Aggregate;
     type Error;
-    type Result: Future<Output = Result<Vec<EventOf<Self::Aggregate>>, Self::Error>>;
 
-    fn handle(&self, state: &StateOf<Self::Aggregate>, command: Self::Command) -> Self::Result;
+    async fn handle(
+        &self,
+        state: &StateOf<Self::Aggregate>,
+        command: Self::Command,
+    ) -> Result<EventOf<Self::Aggregate>, Self::Error>;
 }

--- a/eventually/src/optional.rs
+++ b/eventually/src/optional.rs
@@ -3,7 +3,7 @@
 //! [`Aggregate`]: ../aggregate/trait.Aggregate.html
 //! [`Option`]: https://doc.rust-lang.org/std/option/enum.Option.html
 
-use std::future::Future;
+use async_trait::async_trait;
 
 use crate::{aggregate, command};
 
@@ -19,6 +19,7 @@ use crate::{aggregate, command};
 /// [`Aggregate`]: trait.Aggregate.html
 /// [`command::Handler`]: ../command/trait.Handler.html
 /// [`as_handler`]: trait.CommandHandler.html#method.as_handler
+#[async_trait]
 pub trait CommandHandler {
     /// Commands to trigger a specific use-case on the context of an [`Aggregate`].
     ///
@@ -38,17 +39,6 @@ pub trait CommandHandler {
     /// [`Command`]: trait.CommandHandler.html#associatedType.Command
     type Error;
 
-    /// Result of the [`Command`] handling routine.
-    ///
-    /// Since a [`command::Handler`] usually performs `async` requests to
-    /// external services to handle a [`Command`], the `Result` is expressed
-    /// as a [`Future`].
-    ///
-    /// [`Command`]: trait.CommandHandler.html#associatedType.Command
-    /// [`command::Handler`]: ../command/trait.Handler.html
-    /// [`Future`]: https://doc.rust-lang.org/stable/core/future/trait.Future.html
-    type Result: Future<Output = Result<Vec<EventOf<Self::Aggregate>>, Self::Error>>;
-
     /// Handles a [`Command`] when the [`Aggregate`] state is not yet present.
     ///
     /// Usually this happens when the event store has no persisted event
@@ -56,15 +46,21 @@ pub trait CommandHandler {
     ///
     /// [`Command`]: trait.CommandHandler.html#associatedType.Command
     /// [`Aggregate`]: trait.CommandHandler.html#associatedType.Aggregate
-    fn handle_first(&self, command: Self::Command) -> Self::Result;
+    async fn handle_first(
+        &self,
+        command: Self::Command,
+    ) -> command::Result<EventOf<Self::Aggregate>, Self::Error>;
 
     /// Handles a [`Command`] when the previous [`Aggregate`] state
     /// is already **present** and **available** to the command handler.
     ///
     /// [`Command`]: trait.CommandHandler.html#associatedType.Command
     /// [`Aggregate`]: trait.CommandHandler.html#associatedType.Aggregate
-    fn handle_next(&self, state: &StateOf<Self::Aggregate>, command: Self::Command)
-        -> Self::Result;
+    async fn handle_next(
+        &self,
+        state: &StateOf<Self::Aggregate>,
+        command: Self::Command,
+    ) -> command::Result<EventOf<Self::Aggregate>, Self::Error>;
 
     /// Adapts the [`CommandHandler`] implementation to the [`command::Handler`]
     /// foundation trait, useful when needs to be used with a
@@ -93,24 +89,27 @@ pub trait CommandHandler {
 /// [`CommandHandler.as_handler`]: trait.CommandHandler.html#method.as_handler
 pub struct AsHandler<H>(H);
 
+#[async_trait]
 impl<H> command::Handler for AsHandler<H>
 where
-    H: CommandHandler,
+    H: CommandHandler + Send + Sync,
+    StateOf<H::Aggregate>: Send + Sync,
+    H::Command: Send,
 {
     type Command = H::Command;
     type Aggregate = AsAggregate<H::Aggregate>;
     type Error = H::Error;
-    type Result = H::Result;
 
-    fn handle(
+    async fn handle(
         &self,
         state: &aggregate::StateOf<Self::Aggregate>,
         command: Self::Command,
-    ) -> Self::Result {
+    ) -> command::Result<aggregate::EventOf<Self::Aggregate>, Self::Error> {
         match state {
             None => self.0.handle_first(command),
             Some(state) => self.0.handle_next(state, command),
         }
+        .await
     }
 }
 

--- a/eventually/src/optional.rs
+++ b/eventually/src/optional.rs
@@ -176,7 +176,7 @@ pub trait Aggregate {
 /// # Examples
 ///
 /// ```
-/// use eventually::optional::Aggregate;
+/// use eventually::optional::Aggregate as OptionalAggregate;
 ///
 /// enum SomeEvent {
 ///     Happened
@@ -188,7 +188,7 @@ pub trait Aggregate {
 /// }
 ///
 /// struct SomeAggregate;
-/// impl Aggregate for SomeAggregate {
+/// impl OptionalAggregate for SomeAggregate {
 ///     type State = SomeState;
 ///     type Event = SomeEvent;
 ///     type Error = std::convert::Infallible;
@@ -206,19 +206,17 @@ pub trait Aggregate {
 ///     }
 /// }
 ///
-/// fn main() {
-///     use eventually::Aggregate;
-///     use eventually::optional::AsAggregate;
+/// use eventually::Aggregate;
+/// use eventually::optional::AsAggregate;
 ///
-///     // To adapt SomeAggregate to `eventually::Aggregate`:
-///     let result = AsAggregate::<SomeAggregate>::apply(
-///         None,                   // This state will result in calling `SomeAggregate::apply_first`
-///         SomeEvent::Happened,
-///     );
+/// // To adapt SomeAggregate to `eventually::Aggregate`:
+/// let result = AsAggregate::<SomeAggregate>::apply(
+///     None,                   // This state will result in calling `SomeAggregate::apply_first`
+///     SomeEvent::Happened,
+/// );
 ///
-///     // An `Option`-wrapped `SomeState` instance is returned.
-///     assert_eq!(result, Ok(Some(SomeState {})));
-/// }
+/// // An `Option`-wrapped `SomeState` instance is returned.
+/// assert_eq!(result, Ok(Some(SomeState {})));
 /// ```
 ///
 /// [`Aggregate`]: trait.Aggregate.html

--- a/eventually/src/versioned.rs
+++ b/eventually/src/versioned.rs
@@ -158,25 +158,26 @@ where
 ///     }
 /// }
 ///
-/// fn main() {
-///     use eventually::versioned::{AsAggregate, Versioned};
+/// use eventually::versioned::{AsAggregate, Versioned};
 ///
-///     // Use by wrapping the original type in `AsAggregate::<T>`
-///     let result = AsAggregate::<Entity>::apply(Versioned::default(), Event::SomeEvent);
+/// // Use by wrapping the original type in `AsAggregate::<T>`
+/// let result = AsAggregate::<Entity>::apply(
+///     Versioned::default(),
+///     Versioned::from(Event::SomeEvent)
+/// );
 ///
-///     assert_eq!(
-///         result,
-///         // Wraps the Entity instance with version "1"
-///         Ok(Versioned::with_version(Entity::default(), 1)),
-///     );
+/// assert_eq!(
+///     result,
+///     // `Versioned::from` assigns the default version to the event, which is 0.
+///     // So, the state will take the same version.
+///     Ok(Versioned::with_version(Entity::default(), 0)),
+/// );
 ///
-///     // If applied on a versioned state again, the version will increase
-///     // from "1" to "2"
-///     assert_eq!(
-///         AsAggregate::<Entity>::apply(result.unwrap(), Event::SomeEvent),
-///         Ok(Versioned::with_version(Entity::default(), 2)),
-///     );
-/// }
+/// // If applying an event with version "1", the state will have version "1" too.
+/// assert_eq!(
+///     AsAggregate::<Entity>::apply(result.unwrap(), Versioned::with_version(Event::SomeEvent, 1)),
+///     Ok(Versioned::with_version(Entity::default(), 1)),
+/// );
 /// ```
 ///
 /// [`Aggregate`]: ../aggregate/trait.Aggregate.html


### PR DESCRIPTION
Given the way `async/await` works, having the asynchronous result of `Handler::handle` in an associated type (`type Result`) is very cumbersome until we have GAT support.

The reason for it being the inability to specify the lifetime of the async block, that should capture the same lifetime as the `handle` method invocation.

As a solution, every `command::Handler` implementation should return, instead, a:
```
std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'async>>
```
or, using the `futures` crate, a `futures::future::BoxFuture` type.

Since writing the lifetimes in each `handle` method definition gets tiring very quickly, this PR introduces `async-trait` crate.