### PR TITLE
chore: remove type alias bounds

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,6 +1,5 @@
 [build]
 rustflags = [
-    "-A", "type_alias_bounds",
     "-W", "missing_docs",           # detects missing documentation for public members
     "-W", "trivial_casts",          # detects trivial casts which could be removed
     "-W", "trivial_numeric_casts",  # detects trivial casts of numeric types which could be removed

--- a/eventually-core/src/aggregate.rs
+++ b/eventually-core/src/aggregate.rs
@@ -21,19 +21,19 @@ use futures::{Stream, StreamExt};
 ///
 /// [`State`]: trait.Aggregate.html#associatedtype.State
 /// [`Aggregate`]: trait.Aggregate.html
-pub type StateOf<A: Aggregate> = A::State;
+pub type StateOf<A> = <A as Aggregate>::State;
 
 /// Alias for the [`Event`] type of an [`Aggregate`].
 ///
 /// [`Event`]: trait.Aggregate.html#associatedtype.Event
 /// [`Aggregate`]: trait.Aggregate.html
-pub type EventOf<A: Aggregate> = A::Event;
+pub type EventOf<A> = <A as Aggregate>::Event;
 
 /// Alias for the [`Error`] type of an [`Aggregate`].
 ///
 /// [`Error`]: trait.Aggregate.html#associatedtype.Error
 /// [`Aggregate`]: trait.Aggregate.html
-pub type ErrorOf<A: Aggregate> = A::Error;
+pub type ErrorOf<A> = <A as Aggregate>::Error;
 
 pub trait Identifiable {
     type Id: PartialEq;

--- a/eventually-core/src/command.rs
+++ b/eventually-core/src/command.rs
@@ -2,9 +2,9 @@ use async_trait::async_trait;
 
 use crate::aggregate::{Aggregate, EventOf, StateOf};
 
-pub type CommandOf<H: Handler> = H::Command;
-pub type AggregateOf<H: Handler> = H::Aggregate;
-pub type ErrorOf<H: Handler> = H::Error;
+pub type CommandOf<H> = <H as Handler>::Command;
+pub type AggregateOf<H> = <H as Handler>::Aggregate;
+pub type ErrorOf<H> = <H as Handler>::Error;
 
 pub type Result<Event, Error> = std::result::Result<Vec<Event>, Error>;
 

--- a/eventually-util/src/command/dispatcher.rs
+++ b/eventually-util/src/command/dispatcher.rs
@@ -7,7 +7,7 @@ use eventually_core::store::Store as EventStore;
 use eventually_core::{aggregate, aggregate::AggregateExt};
 use eventually_core::{command, command::Handler as CommandHandler};
 
-pub type SourceIdOf<I: Identifiable> = I::SourceId;
+pub type SourceIdOf<T> = <T as Identifiable>::SourceId;
 
 pub trait Identifiable {
     type SourceId: Eq;

--- a/eventually-util/src/optional.rs
+++ b/eventually-util/src/optional.rs
@@ -117,13 +117,13 @@ where
 ///
 /// [`Aggregate`]: trait.Aggregate.html
 /// [`State`]: trait.Aggregate.html#associatedType.State
-pub type StateOf<A: Aggregate> = A::State;
+pub type StateOf<A> = <A as Aggregate>::State;
 
 /// Extract the [`Event`] from an [`Aggregate`].
 ///
 /// [`Aggregate`]: trait.Aggregate.html
 /// [`Event`]: trait.Aggregate.html#associatedType.Event
-pub type EventOf<A: Aggregate> = A::Event;
+pub type EventOf<A> = <A as Aggregate>::Event;
 
 /// Variation of [`aggregate::Aggregate`] trait, useful when
 /// the Aggregate [`State`] is expressed as an [`Option`].


### PR DESCRIPTION
Remove the current type alias bounds:
```rust
type MyBound<T: Bound> = T::Item;
```
to replace them with the supported version:
```rust
type MyBound<T> = <T as Bound>::Item;
```

This will lower warnings from the compiler.