### PR TITLE
chore: remove async-trait dependency

### DIFF
--- a/eventually-core/Cargo.toml
+++ b/eventually-core/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1"
-futures = "0.3"
+futures = { version = "0.3", features = ["async-await"] }

--- a/eventually-core/src/command.rs
+++ b/eventually-core/src/command.rs
@@ -1,4 +1,4 @@
-use async_trait::async_trait;
+use futures::future::BoxFuture;
 
 use crate::aggregate::{Aggregate, EventOf, StateOf};
 
@@ -8,15 +8,14 @@ pub type ErrorOf<H> = <H as Handler>::Error;
 
 pub type Result<Event, Error> = std::result::Result<Vec<Event>, Error>;
 
-#[async_trait]
 pub trait Handler {
     type Command;
     type Aggregate: Aggregate;
     type Error;
 
-    async fn handle(
-        &self,
-        state: &StateOf<Self::Aggregate>,
+    fn handle<'a, 'b: 'a>(
+        &'a self,
+        state: &'b StateOf<Self::Aggregate>,
         command: Self::Command,
-    ) -> Result<EventOf<Self::Aggregate>, Self::Error>;
+    ) -> BoxFuture<'a, Result<EventOf<Self::Aggregate>, Self::Error>>;
 }

--- a/eventually-core/src/store.rs
+++ b/eventually-core/src/store.rs
@@ -1,7 +1,6 @@
 //! Contains abstractions for the Event Store feature.
 
-use async_trait::async_trait;
-
+use futures::future::BoxFuture;
 use futures::stream::BoxStream;
 
 /// Represents an Event Store, an append-only, ordered list of [`Events`]
@@ -9,7 +8,6 @@ use futures::stream::BoxStream;
 ///
 /// [`Events`]: trait.Store.html#associatedType.Event
 /// [`Aggregate`]: ../aggregate/trait.Aggregate.html
-#[async_trait]
 pub trait Store {
     /// Type of the Source id, usually an [`Aggregate`] id.
     ///
@@ -60,20 +58,20 @@ pub trait Store {
     /// [`Aggregate`]: ../aggregate/trait.Aggregate.html
     /// [`State`]: ../aggregate/trait.Aggregate.html#associatedType.State
     /// [`Aggregate::async_fold`]: ../aggregate/trait.AggregateExt.html#method.async_fold
-    fn stream<'store>(
-        &'store self,
+    fn stream(
+        &self,
         source_id: Self::SourceId,
         from: Self::Offset,
-    ) -> BoxStream<'store, Result<Self::Event, Self::Error>>;
+    ) -> BoxStream<Result<Self::Event, Self::Error>>;
 
     /// Appends a list of new events to the `Store`.
     ///
     /// An [`Error`] is returned if the append operation fails.
     ///
     /// [`Error`]: trait.Store.html#associatedType.Error
-    async fn append(
+    fn append(
         &mut self,
         source_id: Self::SourceId,
         events: Vec<Self::Event>,
-    ) -> Result<(), Self::Error>;
+    ) -> BoxFuture<Result<(), Self::Error>>;
 }

--- a/eventually-examples/Cargo.toml
+++ b/eventually-examples/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1"
-futures = "0.3"
+futures = { version = "0.3", features = ["async-await"] }
 tokio-test = "0.2"
 rand = "0.7"
 

--- a/eventually-memory/Cargo.toml
+++ b/eventually-memory/Cargo.toml
@@ -5,8 +5,7 @@ authors = ["Danilo Cianfrone <danilocianfr@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-async-trait = "0.1"
-futures = "0.3"
+futures = { version = "0.3", features = ["async-await"] }
 
 eventually-core = { path = "../eventually-core" }
 

--- a/eventually-util/Cargo.toml
+++ b/eventually-util/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1"
-futures = "0.3"
+futures = { version = "0.3", features = ["async-await"] }
 
 eventually-core = { path = "../eventually-core" }

--- a/eventually/Cargo.toml
+++ b/eventually/Cargo.toml
@@ -15,11 +15,9 @@ categories = ["ddd", "event-sourcing", "cqrs", "aggregate"]
 keywords = ["architecture", "ddd", "event-sourcing", "cqrs"]
 
 [dependencies]
-async-trait = "0.1"
-futures = "0.3"
-
 eventually-core = { path = "../eventually-core" }
 eventually-util = { path = "../eventually-util" }
 
 [dev-dependencies]
+futures = { version = "0.3", features = ["async-await"] }
 tokio-test = "0.2"

--- a/eventually/examples/optional_point.rs
+++ b/eventually/examples/optional_point.rs
@@ -1,4 +1,5 @@
-use async_trait::async_trait;
+use futures::future;
+use futures::future::BoxFuture;
 
 use eventually::aggregate::{EventOf, ReferentialAggregate, StateOf};
 use eventually::command;
@@ -62,22 +63,21 @@ pub enum PointCommand {
     GoRight(i32),
 }
 
-#[async_trait]
 impl StaticCommandHandler for Point {
     type Command = PointCommand;
     type Aggregate = AsAggregate<Self>;
     type Error = std::convert::Infallible;
 
-    async fn handle(
+    fn handle(
         _state: &StateOf<Self::Aggregate>,
         command: Self::Command,
-    ) -> command::Result<EventOf<Self::Aggregate>, Self::Error> {
-        Ok(vec![match command {
+    ) -> BoxFuture<command::Result<EventOf<Self::Aggregate>, Self::Error>> {
+        Box::pin(future::ok(vec![match command {
             PointCommand::GoUp(y) => PointEvent::WentUp(y),
             PointCommand::GoDown(y) => PointEvent::WentDown(y),
             PointCommand::GoLeft(x) => PointEvent::WentLeft(x),
             PointCommand::GoRight(x) => PointEvent::WentRight(x),
-        }])
+        }]))
     }
 }
 


### PR DESCRIPTION
In an effort to reduce the number of indirect dependencies introduced by the crate, the `async-trait`, albeit small, has been removed.

Replaced by explicit `futures::future::BoxFuture` return types and `Box::pin`-wrapped functions.

Also, `futures` has been pointed to `features = ["async-await"]`, to reduce the number of dependencies introduced by it. 