### PR TITLE
feat: Projection trait is now async and might fail

### DIFF
--- a/eventually-core/src/projection.rs
+++ b/eventually-core/src/projection.rs
@@ -7,6 +7,8 @@
 //! [`Projection`]: trait.Projection.html
 //! [`Aggregate`]: ../aggregate/trait.Aggregate.html
 
+use futures::future::BoxFuture;
+
 use crate::store::Persisted;
 
 /// A `Projection` is an optimized read model (or materialized view)
@@ -18,7 +20,7 @@ use crate::store::Persisted;
 ///
 /// [`Aggregate`]: ../aggregate/trait.Aggregate.html
 /// [`EventStore`]: ../store/trait.EventStore.html
-pub trait Projection: Default {
+pub trait Projection {
     /// Type of the Source id, typically an [`AggregateId`].
     ///
     /// [`AggregateId`]: ../aggregate/type.AggregateId.html
@@ -29,7 +31,13 @@ pub trait Projection: Default {
     /// [`Aggregate::Event`]: ../aggregate/trait.Aggregate.html#associatedtype.Event
     type Event;
 
-    /// Updates the next value of the `Projection` using the provided
-    /// event value.
-    fn project(self, event: Persisted<Self::SourceId, Self::Event>) -> Self;
+    /// Type of the possible error that might occur when projecting
+    /// the next state.
+    type Error;
+
+    /// Updates the next value of the `Projection` using the provided event value.
+    fn project<'a>(
+        &'a mut self,
+        event: Persisted<Self::SourceId, Self::Event>,
+    ) -> BoxFuture<'a, Result<(), Self::Error>>;
 }

--- a/eventually-test/src/api.rs
+++ b/eventually-test/src/api.rs
@@ -69,7 +69,7 @@ pub(crate) async fn history(req: Request<AppState>) -> Result<Response, Error> {
         .await
         .map_err(Error::from)?
         .try_filter(|event| {
-            futures::future::ready(match from {
+            ready(match from {
                 None => true,
                 Some(from) => event.happened_at() >= &from,
             })

--- a/eventually-test/src/lib.rs
+++ b/eventually-test/src/lib.rs
@@ -9,8 +9,6 @@ use eventually::aggregate::Optional;
 use eventually::inmemory::{EventStoreBuilder, ProjectorBuilder};
 use eventually::{AggregateRootBuilder, Repository};
 
-use futures::stream::StreamExt;
-
 use tokio::sync::RwLock;
 
 use crate::config::Config;

--- a/eventually-test/src/lib.rs
+++ b/eventually-test/src/lib.rs
@@ -38,18 +38,13 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     // Put the store behind an Arc to allow for clone-ness of a single instance.
     let store = Arc::new(store);
 
+    // Create a new in-memory projection to keep the total orders computed by
+    // the application.
+    let total_orders_projection = Arc::new(RwLock::new(TotalOrdersProjection::default()));
+
     // Create a new Projector for the desired projection.
     let mut total_orders_projector =
-        ProjectorBuilder::new(store.clone(), store.clone()).build::<TotalOrdersProjection>();
-
-    // Get a watch channel from the Projector: updates to the projector values
-    // will be sent here.
-    let mut total_orders_projector_rx = total_orders_projector.watch();
-
-    // Keep the projection value in memory.
-    // We can use it to access it from the context of an endpoint and serialize the read model.
-    let total_orders_projection = Arc::new(RwLock::new(TotalOrdersProjection::default()));
-    let total_orders_projection_state = total_orders_projection.clone();
+        ProjectorBuilder::new(store.clone(), store.clone()).build(total_orders_projection.clone());
 
     // Spawn a dedicated coroutine to run the projector.
     //
@@ -57,19 +52,6 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     // it will receive all oldest and newest events as they come into the EventStore,
     // and it will progressively update the projection as events arrive.
     tokio::spawn(async move { total_orders_projector.run().await.expect("should not fail") });
-
-    // Spawn a dedicated coroutine to listen to changes to the projection.
-    //
-    // In this case we're logging the latest version, but in more advanced
-    // scenario you might want to do something more with it.
-    //
-    // In some cases you might not need to watch the projection changes.
-    tokio::spawn(async move {
-        while let Some(total_orders) = total_orders_projector_rx.next().await {
-            log::info!("Total orders: {:?}", total_orders);
-            *total_orders_projection_state.write().await = total_orders;
-        }
-    });
 
     // Set up the HTTP router.
     let mut app = tide::new();


### PR DESCRIPTION
Related to #93

Projections should fully own the data storage method used.

Considering these storage might be (most likely) external database (e.g. Postgres tables), the trait's `project` method has to become a `Future`, and might potentially fail in case of connection error.