### PR TITLE
fix(eventually-postgres): overflow caused by i64 to u32 conversion

### DIFF
--- a/eventually-postgres/src/subscription.rs
+++ b/eventually-postgres/src/subscription.rs
@@ -3,7 +3,7 @@
 //!
 //! [`Subscription`]: ../../eventually-core/subscription/trait.Subscription.html
 
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 use std::error::Error as StdError;
 use std::fmt::Display;
 use std::sync::atomic::{AtomicI64, Ordering};
@@ -143,7 +143,12 @@ where
             //
             // In the initial case, the last_sequence_number
             // would be -1, which will load everything from the start.
-            let checkpoint = (self.last_sequence_number.load(Ordering::Relaxed) as u32) + 1;
+            let checkpoint: u32 = (self.last_sequence_number.load(Ordering::Relaxed) + 1)
+                .try_into()
+                .expect(
+                    "in case of overflow, it means there is a bug in the optimistic versioning code; \\
+                    please open an issue with steps to reproduce the bug"
+                );
 
             tracing::debug!(
                 subscription.checkpoint = checkpoint,

--- a/eventually-postgres/tests/subscriber.rs
+++ b/eventually-postgres/tests/subscriber.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use eventually_core::store::{EventStore, Expected, Persisted};
-use eventually_core::subscription::EventSubscriber as EventSubscriberTrait;
-use eventually_postgres::{EventStoreBuilder, EventSubscriber};
+use eventually_core::subscription::{EventSubscriber as EventSubscriberTrait, Subscription};
+use eventually_postgres::{EventStoreBuilder, EventSubscriber, PersistentBuilder};
 
 use futures::stream::{StreamExt, TryStreamExt};
 
@@ -70,6 +70,94 @@ async fn subscribe_all_works() {
         .expect("failed while appending events");
 
     let events: Vec<Persisted<String, Event>> = subscription
+        .take(3)
+        .try_collect()
+        .await
+        .expect("failed to collect events from subscription");
+
+    assert_eq!(
+        vec![
+            Persisted::from(source_id.to_owned(), Event::A)
+                .version(1)
+                .sequence_number(0),
+            Persisted::from(source_id.to_owned(), Event::B)
+                .version(2)
+                .sequence_number(1),
+            Persisted::from(source_id.to_owned(), Event::C)
+                .version(3)
+                .sequence_number(2)
+        ],
+        events
+    );
+}
+
+#[tokio::test]
+async fn persistent_subscription_works() {
+    let docker = testcontainers::clients::Cli::default();
+    let postgres_image = testcontainers::images::postgres::Postgres::default();
+    let node = docker.run(postgres_image);
+
+    let dsn = format!(
+        "postgres://postgres:postgres@localhost:{}/postgres",
+        node.get_host_port(5432).unwrap()
+    );
+
+    let (mut client, connection) = tokio_postgres::connect(&dsn, tokio_postgres::NoTls)
+        .await
+        .expect("could not connect to the docker container");
+
+    tokio::spawn(async move {
+        connection
+            .await
+            .expect("connection with the database exited with error")
+    });
+
+    let source_name = "persistent_subscription_test";
+    let source_id = "persistent_subscription_test";
+
+    let event_store_builder = EventStoreBuilder::migrate_database(&mut client)
+        .await
+        .expect("failed to run database migrations")
+        .builder(Arc::new(client));
+
+    let mut event_store = event_store_builder
+        .build::<String, Event>(source_name)
+        .await
+        .expect("failed to create event store");
+
+    let event_subscriber = EventSubscriber::<String, Event>::new(&dsn, source_name)
+        .await
+        .expect("failed to create event subscription");
+
+    let (client, connection) = tokio_postgres::connect(&dsn, tokio_postgres::NoTls)
+        .await
+        .expect("could not connect to the docker container");
+
+    tokio::spawn(async move {
+        connection
+            .await
+            .expect("connection with the database exited with error")
+    });
+
+    let subscription =
+        PersistentBuilder::new(Arc::new(client), event_store.clone(), event_subscriber)
+            .get_or_create(source_name.to_owned())
+            .await
+            .expect("failed to create persistent subscription");
+
+    event_store
+        .append(
+            source_id.to_owned(),
+            Expected::Exact(0),
+            vec![Event::A, Event::B, Event::C],
+        )
+        .await
+        .expect("failed while appending events");
+
+    let events: Vec<Persisted<String, Event>> = subscription
+        .resume()
+        .await
+        .expect("failed to resume subscription")
         .take(3)
         .try_collect()
         .await


### PR DESCRIPTION
When creating new empty Persistent Subscriptions on Postgres, the previous checkpoint code would panic, due to an unchecked `i64` to `u32` conversion.